### PR TITLE
Requests fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import traceback
 from urllib.parse import quote
 
 import pandas as pd
+import requests
 from sqlalchemy.schema import DropTable
 from sqlalchemy import inspect
 from sqlalchemy.exc import NoSuchTableError


### PR DESCRIPTION
`engine.has_table` is going to be deprecated so I updated to their recommended `Inspector.has_table`.

Also the connector was failing because `Connector.create_student_accounts` was trying to catch an error, but requests has not been imported. The job doesn't fail with these errors though. Is that problematic?